### PR TITLE
feature: 선물하기 선착순 당첨자 DB에 저장

### DIFF
--- a/gift-core/src/main/java/com/kakaotalk/gift/domain/member/domain/Member.java
+++ b/gift-core/src/main/java/com/kakaotalk/gift/domain/member/domain/Member.java
@@ -2,7 +2,6 @@ package com.kakaotalk.gift.domain.member.domain;
 
 import com.kakaotalk.gift.domain.openroom.domain.OpenRoom;
 import com.kakaotalk.gift.domain.openroom.domain.OpenRoomMapping;
-import com.kakaotalk.gift.domain.receivedgiftbox.domain.ReceivedGiftBox;
 import com.kakaotalk.gift.domain.sendgiftbox.domian.SendGiftBox;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -38,9 +37,6 @@ public class Member {
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     private List<SendGiftBox> sendGiftBoxes = new ArrayList<>();
-
-    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
-    private List<ReceivedGiftBox> receivedGiftBoxes = new ArrayList<>();
 
     public Member(String id) {
         this.id = id;

--- a/gift-core/src/main/java/com/kakaotalk/gift/domain/receivedgiftbox/application/ReceivedGiftService.java
+++ b/gift-core/src/main/java/com/kakaotalk/gift/domain/receivedgiftbox/application/ReceivedGiftService.java
@@ -1,6 +1,10 @@
 package com.kakaotalk.gift.domain.receivedgiftbox.application;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.kakaotalk.gift.domain.receivedgiftbox.dao.ReceivedGiftBoxRepository;
+import com.kakaotalk.gift.domain.receivedgiftbox.domain.ReceivedGiftBox;
+import com.kakaotalk.gift.domain.sendgiftbox.dao.SendGiftBoxDao;
+import com.kakaotalk.gift.domain.sendgiftbox.domian.SendGiftBox;
 import com.kakaotalk.gift.infra.redis.util.Event;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,6 +12,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.Set;
 
 
@@ -18,15 +23,39 @@ import java.util.Set;
 public class ReceivedGiftService {
 
     private final RedisTemplate redisTemplate;
+    private final SendGiftBoxDao sendGiftBoxDao;
+    private final ReceivedGiftBoxRepository receivedGiftBoxRepository;
 
     public void create(Set<Object> events) throws JsonProcessingException {
         for (Object event : events) {
             if (event instanceof Event) {
                 Event e = (Event) event;
-                log.info("{} 님이 기프티콘에 당첨되었습니다.", e.getMemberId());
-                redisTemplate.opsForValue().decrement(e.getGiftSerialCode());
-                redisTemplate.opsForZSet().remove(e.secondKey(), event);
+                String giftSerialCode = e.getGiftSerialCode();
+                String memberId = e.getMemberId();
+                String secondKey = e.secondKey();
+                Optional<SendGiftBox> optionalSendGiftBox = sendGiftBoxDao.findByGiftSerialCode(giftSerialCode);
+
+                optionalSendGiftBox.ifPresent(sendGiftBox -> {
+                            if (sendGiftBox.hasAvailableQuantity()) {
+                                sendGiftBox.decreaseAvailableQuantity();
+                                ReceivedGiftBox receivedGiftBox = new ReceivedGiftBox(memberId, sendGiftBox);
+                                receivedGiftBoxRepository.save(receivedGiftBox);
+                                log.info("{} 님이 기프티콘에 당첨되었습니다.", e.getMemberId());
+                                decreaseAvailableQuantity(giftSerialCode); // 수량 감소
+                                removeKey(secondKey, event);               // 게임 당첨자 redis에서 삭제
+                            }
+                        }
+                );
             }
         }
+    }
+
+    private void decreaseAvailableQuantity(String giftSerialCode) {
+        Long quantity = redisTemplate.opsForValue().decrement(giftSerialCode);
+        log.info("남은 수량: "  + quantity);
+    }
+
+    private void removeKey(String key, Object event) {
+        redisTemplate.opsForZSet().remove(key, event);
     }
 }

--- a/gift-core/src/main/java/com/kakaotalk/gift/domain/receivedgiftbox/dao/ReceivedGiftBoxRepository.java
+++ b/gift-core/src/main/java/com/kakaotalk/gift/domain/receivedgiftbox/dao/ReceivedGiftBoxRepository.java
@@ -1,0 +1,7 @@
+package com.kakaotalk.gift.domain.receivedgiftbox.dao;
+
+import com.kakaotalk.gift.domain.receivedgiftbox.domain.ReceivedGiftBox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReceivedGiftBoxRepository extends JpaRepository<ReceivedGiftBox, Long> {
+}

--- a/gift-core/src/main/java/com/kakaotalk/gift/domain/receivedgiftbox/domain/ReceivedGiftBox.java
+++ b/gift-core/src/main/java/com/kakaotalk/gift/domain/receivedgiftbox/domain/ReceivedGiftBox.java
@@ -1,6 +1,5 @@
 package com.kakaotalk.gift.domain.receivedgiftbox.domain;
 
-import com.kakaotalk.gift.domain.member.domain.Member;
 import com.kakaotalk.gift.domain.sendgiftbox.domian.SendGiftBox;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -18,16 +17,22 @@ public class ReceivedGiftBox {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
 
+    @Comment(value = "유저의 아이디")
+    @Column(name = "member_id", nullable = false, updatable = false)
+    private String memberId;
+
     @Comment(value = "생성일")
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @OneToOne
+    @Comment(value = "보낸 선물함의 PK")
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "send_gift_box_idx", foreignKey = @ForeignKey(name = "fk_received_gift_box_send_gift_box"))
     private SendGiftBox sendGiftBox;
 
-    @Comment(value = "유저의 아이디")
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_idx", foreignKey = @ForeignKey(name = "fk_received_gift_box_member"))
-    private Member member;
+    public ReceivedGiftBox(String memberId, SendGiftBox sendGiftBox) {
+        this.memberId = memberId;
+        this.sendGiftBox = sendGiftBox;
+        this.createdAt = LocalDateTime.now();
+    }
 }

--- a/gift-core/src/main/java/com/kakaotalk/gift/domain/sendgiftbox/dao/SendGiftBoxDao.java
+++ b/gift-core/src/main/java/com/kakaotalk/gift/domain/sendgiftbox/dao/SendGiftBoxDao.java
@@ -1,11 +1,36 @@
 package com.kakaotalk.gift.domain.sendgiftbox.dao;
 
+import com.kakaotalk.gift.domain.sendgiftbox.domian.SendGiftBox;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.kakaotalk.gift.domain.sendgiftbox.domian.QSendGiftBox.sendGiftBox;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class SendGiftBoxDao {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Optional<SendGiftBox> findByGiftSerialCode(String giftSerialCode) {
+        SendGiftBox result = queryFactory
+                .selectFrom(sendGiftBox)
+                .where(
+                        eqGiftSerialCode(giftSerialCode)
+                )
+                .fetchFirst();
+
+        return Optional.ofNullable(result);
+    }
+
+    private BooleanExpression eqGiftSerialCode(String giftSerialCode) {
+        if (giftSerialCode == null) return null;
+        return sendGiftBox.giftSerialCode.giftSerialCode.eq(giftSerialCode);
+    }
 }

--- a/gift-core/src/main/java/com/kakaotalk/gift/domain/sendgiftbox/domian/SendGiftBox.java
+++ b/gift-core/src/main/java/com/kakaotalk/gift/domain/sendgiftbox/domian/SendGiftBox.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.Comment;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "send_gift_box")
@@ -43,8 +44,8 @@ public class SendGiftBox {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @OneToOne(mappedBy = "sendGiftBox")
-    private ReceivedGiftBox receivedGiftBox;
+    @OneToMany(mappedBy = "sendGiftBox", fetch = FetchType.LAZY)
+    private List<ReceivedGiftBox> receivedGiftBoxes;
 
     @Comment(value = "선물한 유저의 아이디")
     @ManyToOne(fetch = FetchType.LAZY)
@@ -65,6 +66,17 @@ public class SendGiftBox {
 
     public String getGiftSerialCode() {
         return this.giftSerialCode.getGiftSerialCode();
+    }
+
+    public void decreaseAvailableQuantity() {
+        if (this.availableQuantity <= 0) {
+            return;
+        }
+        this.availableQuantity -= 1;
+    }
+
+    public boolean hasAvailableQuantity() {
+        return this.availableQuantity > 0;
     }
 
     private void validatorMember(Member member) {


### PR DESCRIPTION
1. 선물하기 선착순 당첨자를 DB에 저장한다.
2. 선물하기 선착순 당첨자는 redis에서 삭제한다.
3. 선물하기 수량이 0이 되면 해당 게임을 종료 시키고, redis에서 삭제시킨다.

현재 선물하기 선착순 당첨자를 DB에 저장시키면서 해당 service가 redis에 너무 의존적인 느낌을 띄고 있으므로, 의존성을 줄여줄 필요가 있어보임 -> 리팩토링 진행 예정